### PR TITLE
Add Travis Jobs for upm-site

### DIFF
--- a/.bundle/config
+++ b/.bundle/config
@@ -1,0 +1,3 @@
+---
+BUNDLE_PATH: "vendor/bundle"
+BUNDLE_DISABLE_SHARED_GEMS: "true"

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules
 assets
 .publish/
 npm-debug.log
+vendor/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "upm"]
+	path = upm
+	url = https://github.com/intel-iot-devkit/upm

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+dist: trusty
+sudo: required
+
+language: cpp
+
+services:
+  - docker
+
+before_install:
+  - sudo rm /usr/local/bin/docker-compose
+  - curl -L https://github.com/docker/compose/releases/download/1.16.1/docker-compose-`uname -s`-`uname -m` > docker-compose
+  - chmod +x docker-compose
+  - sudo mv docker-compose /usr/local/bin
+
+before_script:
+  - docker-compose build app
+
+script:
+  - docker-compose run app bash -c 'npm install && bundle install && gulp build'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM node:latest
+
+# Install Ruby Tools
+RUN apt-get update && apt-get install -y ruby ruby-dev && \
+    gem install sass bundler --no-user-install
+
+# Install Global Node.js Tools
+RUN npm install -g gulp
+
+# Expose port for development
+EXPOSE 1234
+EXPOSE 3001
+
+# Set Workdir to the mounted directory
+WORKDIR /usr/src/app
+
+CMD bash

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,7 +52,7 @@ DEPENDENCIES
   tzinfo-data
 
 RUBY VERSION
-   ruby 2.2.3p173
+   ruby 2.1.5p273
 
 BUNDLED WITH
-   1.15.3
+   1.15.4

--- a/README.md
+++ b/README.md
@@ -1,17 +1,24 @@
+# UPM Website [![Build Status](https://travis-ci.org/intel-iot-devkit/upm-site.svg?branch=master)](https://travis-ci.org/intel-iot-devkit/upm-site)
+
 ## GitHub Pages URL: https://intel-iot-devkit.github.io/upm/
 ## Dependencies:
-* NodeJs
-* Gulp
+* [NodeJs](https://nodejs.org/en/)
+* [Gulp](https://github.com/gulpjs/gulp)
+* [Python](https://www.python.org/), specifically Python 2!
+* [Ruby](https://www.ruby-lang.org/en/)
+* [Sass](http://sass-lang.com/)
+* [Bundler](http://bundler.io/)
 * A bunch of other stuff installed through bundle and ruby gems
 
 ## Prepare Dev Environment:
-* Run npm install, in the same directory as the code. This will install all the dependencies automatically
+* Run `npm install`, in the same directory as the code. This will install all the  dependencies automatically
+* Run `bundler install` to install Gems dependencies automatically
 
 ## Gulp Tasks:
-1. clean: to clean local build directories and resources
-2. build: to generate the build for production using _config.yml, deploys to /_site
-3. build:local: to generated the build using _config_dev.yml
-4. serve: runs the app locally, using the _config_dev.yml file
+1. `gulp clean`: to clean local build directories and resources
+2. `gulp build`: to generate the build for production using _config.yml, deploys to /_site
+3. `gulp build:local`: to generated the build using _config_dev.yml
+4. `gulp serve`: runs the app locally, using the _config_dev.yml file
 
 ## Global.yml
 * Urls defined for fetching images, source code, and apis

--- a/_assets/gulp_config/paths.js
+++ b/_assets/gulp_config/paths.js
@@ -5,6 +5,7 @@
  * whitespace.
  */
 
+var path = require('path');
 var paths = {};
 
 // Directory locations.
@@ -43,7 +44,7 @@ paths.jsPattern            = '/**/*.js';
 paths.facetFile            = '/facets.json';
 paths.jsonPattern          = '/**/*.json';
 paths.sensorDataFile       = '/sensorDetail.json';
-paths.sensorDataSrc        = undefined; //point to the UPM project src directory
+paths.sensorDataSrc        = path.join(__dirname, '../../upm/src'); //point to the UPM project src directory
 paths.indexFile            = '/LunrIndex.json';
 paths.imagePattern         = '/**/*.+(jpg|JPG|jpeg|JPEG|png|PNG|svg|SVG|gif|GIF|webp|WEBP|tif|TIF)';
 paths.imageFilesGlob       = paths.imageFiles + paths.imagePattern;

--- a/_config.yml
+++ b/_config.yml
@@ -1,20 +1,23 @@
 # Where things are
-source:      .
-destination: ./_site
-plugins_dir:     ./_plugins
-layouts_dir:     ./_layouts
-data_dir: ./_data
+source:       .
+destination:  ./_site
+plugins_dir:  ./_plugins
+layouts_dir:  ./_layouts
+data_dir:     ./_data
 # collections: null
 
 # Handling Reading
 safe:         false
 include:      [".htaccess"]
-exclude:      ["Gemfile",
-               "Gemfile.lock",
-               "gulpfile.js",
-               "node_modules",
-               "package.json",
-               "GemFile"]
+exclude:      [
+                "Gemfile",
+                "Gemfile.lock",
+                "gulpfile.js",
+                "node_modules",
+                "package.json",
+                "GemFile",
+                "vendor"
+              ]
 keep_files:   [".git", ".svn"]
 encoding:     "utf-8"
 markdown_ext: "markdown,mkdown,mkdn,mkd,md"

--- a/_config_dev.yml
+++ b/_config_dev.yml
@@ -1,6 +1,6 @@
 # Serving
-detach:  false
-port:    1234
-host:    127.0.0.1
-baseurl: "" # does not include hostname
-giturl: https://github.com
+detach:     false
+port:       1234
+host:       127.0.0.1
+baseurl:    "" # does not include hostname
+giturl:     https://github.com

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,23 @@
+version: '3'
+
+services:
+
+  app:
+    image: upm-site
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        - http_proxy
+        - https_proxy
+        - no_proxy
+    environment:
+      - http_proxy
+      - https_proxy
+      - no_proxy
+    volumes:
+      - .:/usr/src/app
+    ports:
+      - 1234:1234
+      - 3001:3001
+    command: bash -c 'npm install && bundle install && gulp serve'

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -197,7 +197,12 @@ gulp.task('build:index', function() {
     var sensorData = [];
     for (var i=0; i < sensorDataFile.length ; i++) { // Add the data to lunr
         var sensorDataLibrary = sensorDataFile[i]["Sensor Class"]
-        for(key in sensorDataLibrary){
+        for(key in sensorDataLibrary) {
+            // TODO: Temporary fix, improve
+            if(key === '// TemplateItem') {
+              continue;
+            }
+
             sensorData.push({
                 'id': key,
                 'name': key,


### PR DESCRIPTION
*This PR is not yet ready to merge, is just to validate an approach to build automation with Travis.*

I started with trying to install the dependencies (and document them in the process) for this site-generator. At one moment, to build sass, I need Visual Studio in my Windows box, so I end up going with docker for building the site. 

Basically, this is a bunch of Markdown files, that use Node.js to process it, but depends on Ruby and some Gems for the actual generation (I think sass, jekyll, and some other Gems).

**Dockerfile** has all the tools you need to build this site (I hope)

**docker-compose** is just a placeholder to work with Docker in a proxy environment, so you don't need to pass all the build args and env var to the docker client

**.bundle/config** is a config file for bundler, to install dependencies locally instead of in the global Gem files directory. Now, all the dependencies are installed in the `vendor/` folder, and that folder is added to **.gitignore**

**.gitmodules** has a new reference to an upm repository declared as a submodule. This repo **must have an upm repo for building**, so I thought it could be usefull to just have it declared as a submodule. **_assets/gulp_config/paths.js** has now a reference to that upm submodule.

**gulpfile.js** now have an ugly fix for skipping the Sensor Template. I hope I can find a better way to do it.

**.travis.yaml** has the travis jobs description. You can see the first successful execution here https://travis-ci.org/intel-iot-devkit/upm-site. My objective is to run the site deploy Job automatically in Travis, but that is not implemented yet. **README.md** has been updated to hold the travis ci badge, and some other documentation like dependencies and commands to be executed

Other files have indentation changes as well

Signed-off-by: Nicolas Oliver <dario.n.oliver@intel.com>